### PR TITLE
Fixed Luhn Summarizer for Crystal 0.31.0

### DIFF
--- a/src/cadmium/summarizer/luhn_summarizer.cr
+++ b/src/cadmium/summarizer/luhn_summarizer.cr
@@ -33,7 +33,7 @@ module Cadmium
       window_size = window_size(terms_in_sentence, normalized_terms)
       return 0 if window_size <= 0
       number_of_normalized_terms = terms_in_sentence.count { |term| normalized_terms.includes?(term) }
-      (number_of_normalized_terms*number_of_normalized_terms) / window_size
+      (number_of_normalized_terms*number_of_normalized_terms) // window_size
     end
 
     private def select_sentences(text, max_num_sentences, normalized_terms_ratio)


### PR DESCRIPTION
The / operator was changed to return floats: https://github.com/crystal-lang/crystal/pull/8120. This change preserves previous behaviour (floor).